### PR TITLE
feat: Backend core — machine registration, scan ingestion, Health Score engine

### DIFF
--- a/app/server/main.py
+++ b/app/server/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import health
+from routers import health, machines, scans
 
 app = FastAPI(title="SysDoc API", version="0.1.0")
 
@@ -13,3 +13,5 @@ app.add_middleware(
 )
 
 app.include_router(health.router)
+app.include_router(machines.router)
+app.include_router(scans.router)

--- a/app/server/models/schemas.py
+++ b/app/server/models/schemas.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class MachineRegisterRequest:
+    machine_id: str
+    hostname: str | None = None
+    os_name: str | None = None
+    os_arch: str | None = None
+    cpu_model: str | None = None
+    cpu_cores: int | None = None
+    ram_total_gb: float | None = None
+
+
+@dataclass
+class MachineRegisterResponse:
+    id: str
+    machine_id: str
+    created: bool
+
+
+@dataclass
+class ScanResponse:
+    scan_id: str
+    health_score: int
+    issues_detected: int
+
+
+@dataclass
+class Issue:
+    code: str
+    severity: str
+    title: str
+    description: str
+    fix_available: bool = False
+    fix_command: str | None = None
+
+
+@dataclass
+class ScoreResult:
+    health_score: int
+    score_performance: int
+    score_storage: int
+    score_security: int
+    score_stability: int
+
+
+@dataclass
+class ScanPayload:
+    machine_id: str
+    collected_at: str | None = None
+    cpu: dict[str, Any] = field(default_factory=dict)
+    memory: dict[str, Any] = field(default_factory=dict)
+    disk: dict[str, Any] = field(default_factory=dict)
+    network: dict[str, Any] = field(default_factory=dict)
+    processes: dict[str, Any] = field(default_factory=dict)
+    startup: dict[str, Any] = field(default_factory=dict)

--- a/app/server/pyproject.toml
+++ b/app/server/pyproject.toml
@@ -13,3 +13,10 @@ dependencies = [
     "supabase>=2.29.0",
     "uvicorn[standard]>=0.46.0",
 ]
+
+[dependency-groups]
+dev = [
+    "httpx>=0.28.1",
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+]

--- a/app/server/routers/machines.py
+++ b/app/server/routers/machines.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from db.supabase import get_client
+
+router = APIRouter(prefix="/api/v1")
+
+
+class MachineRegisterBody(BaseModel):
+    machine_id: str
+    hostname: str | None = None
+    os_name: str | None = None
+    os_arch: str | None = None
+    cpu_model: str | None = None
+    cpu_cores: int | None = None
+    ram_total_gb: float | None = None
+
+
+@router.post("/machines/register")
+async def register_machine(body: MachineRegisterBody):
+    db = get_client()
+
+    existing = (
+        db.table("machines")
+        .select("id, machine_id")
+        .eq("machine_id", body.machine_id)
+        .execute()
+    )
+
+    if existing.data:
+        row = existing.data[0]
+        db.table("machines").update({"last_seen": "now()"}).eq("machine_id", body.machine_id).execute()
+        return {"id": row["id"], "machine_id": row["machine_id"], "created": False}
+
+    result = (
+        db.table("machines")
+        .insert({
+            "machine_id": body.machine_id,
+            "hostname": body.hostname,
+            "os_name": body.os_name,
+            "os_arch": body.os_arch,
+            "cpu_model": body.cpu_model,
+            "cpu_cores": body.cpu_cores,
+            "ram_total_gb": body.ram_total_gb,
+        })
+        .execute()
+    )
+
+    if not result.data:
+        raise HTTPException(status_code=500, detail="Failed to register machine")
+
+    row = result.data[0]
+    return {"id": row["id"], "machine_id": row["machine_id"], "created": True}

--- a/app/server/routers/scans.py
+++ b/app/server/routers/scans.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+from typing import Any
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from db.supabase import get_client
+from services.analyzer import analyze
+from services.scorer import calculate
+from services.metrics_writer import extract
+
+router = APIRouter(prefix="/api/v1")
+
+
+class ScanBody(BaseModel):
+    machine_id: str | None = None
+    collected_at: str | None = None
+    cpu: dict[str, Any] = {}
+    memory: dict[str, Any] = {}
+    disk: dict[str, Any] = {}
+    network: dict[str, Any] = {}
+    processes: dict[str, Any] = {}
+    startup: dict[str, Any] = {}
+
+
+@router.post("/machines/{machine_id}/scan")
+async def ingest_scan(machine_id: str, body: ScanBody):
+    db = get_client()
+
+    machine = (
+        db.table("machines")
+        .select("id")
+        .eq("machine_id", machine_id)
+        .execute()
+    )
+    if not machine.data:
+        raise HTTPException(status_code=404, detail="Machine not registered")
+
+    machine_uuid = machine.data[0]["id"]
+    payload = body.model_dump()
+
+    issues = analyze(payload)
+    score_result = calculate(issues)
+
+    scan = (
+        db.table("scans")
+        .insert({
+            "machine_id": machine_uuid,
+            "health_score": score_result.health_score,
+            "score_performance": score_result.score_performance,
+            "score_storage": score_result.score_storage,
+            "score_security": score_result.score_security,
+            "score_stability": score_result.score_stability,
+            "raw_data": payload,
+        })
+        .execute()
+    )
+
+    if not scan.data:
+        raise HTTPException(status_code=500, detail="Failed to save scan")
+
+    scan_uuid = scan.data[0]["id"]
+
+    if issues:
+        db.table("issues").insert([
+            {
+                "scan_id": scan_uuid,
+                "machine_id": machine_uuid,
+                "issue_code": issue.code,
+                "severity": issue.severity,
+                "title": issue.title,
+                "description": issue.description,
+                "fix_available": issue.fix_available,
+                "fix_command": issue.fix_command,
+            }
+            for issue in issues
+        ]).execute()
+
+    metrics = extract(machine_uuid, payload)
+    db.table("metrics").insert(metrics).execute()
+
+    db.table("machines").update({"last_seen": "now()"}).eq("id", machine_uuid).execute()
+
+    return {
+        "scan_id": scan_uuid,
+        "health_score": score_result.health_score,
+        "issues_detected": len(issues),
+    }
+
+
+@router.get("/machines/{machine_id}/scans/latest")
+async def get_latest_scan(machine_id: str):
+    db = get_client()
+
+    machine = db.table("machines").select("id").eq("machine_id", machine_id).execute()
+    if not machine.data:
+        raise HTTPException(status_code=404, detail="Machine not found")
+
+    machine_uuid = machine.data[0]["id"]
+
+    scan = (
+        db.table("scans")
+        .select("*")
+        .eq("machine_id", machine_uuid)
+        .order("scanned_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+
+    if not scan.data:
+        return None
+
+    scan_data = scan.data[0]
+    scan_uuid = scan_data["id"]
+
+    issues = (
+        db.table("issues")
+        .select("*")
+        .eq("scan_id", scan_uuid)
+        .is_("resolved_at", None)
+        .execute()
+    )
+
+    return {**scan_data, "issues": issues.data}

--- a/app/server/services/analyzer.py
+++ b/app/server/services/analyzer.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+from models.schemas import Issue
+
+KNOWN_AV = frozenset({
+    "msmpeng", "mrt", "malwarebytes", "avast", "avgnt", "mcshield",
+    "norton", "ccsvchst", "bitdefender", "AvastSvc",
+})
+
+
+def _get(data: dict, *keys: str, default=None):
+    for k in keys:
+        if not isinstance(data, dict):
+            return default
+        data = data.get(k, default)  # type: ignore
+    return data
+
+
+def detect_p01(payload: dict) -> list[Issue]:
+    cpu = payload.get("cpu", {})
+    freq = cpu.get("cpu_freq_mhz")
+    freq_max = cpu.get("cpu_freq_max_mhz")
+    temp = cpu.get("cpu_temp_c")
+    throttling = cpu.get("throttling_detected", False)
+    if throttling and temp and temp > 85:
+        pct = round(freq / freq_max * 100) if freq and freq_max else 0
+        return [Issue(
+            code="P01", severity="high",
+            title="CPU thermal throttling detected",
+            description=(
+                f"Your CPU is running at {pct}% of its max speed due to high temperature "
+                f"({temp}°C). This can cause slowdowns across all applications. "
+                "Like a car engine overheating, your CPU is slowing itself down to cool off. "
+                "Consider cleaning dust from vents or replacing thermal paste."
+            ),
+            fix_available=False,
+        )]
+    return []
+
+
+def detect_p02(payload: dict) -> list[Issue]:
+    smart = _get(payload, "disk", "smart_data") or {}
+    pending = smart.get("pending_sectors", 0) or 0
+    reallocated = smart.get("reallocated_sectors", 0) or 0
+    if pending > 0 or reallocated > 5:
+        return [Issue(
+            code="P02", severity="critical",
+            title="Hard drive sector errors detected",
+            description=(
+                f"Your hard drive has {pending} pending and {reallocated} reallocated sectors. "
+                "These are early signs of drive failure. Back up your data immediately. "
+                "Think of it like cracks appearing in a road — they will get worse over time."
+            ),
+            fix_available=False,
+        )]
+    return []
+
+
+def detect_p03(payload: dict) -> list[Issue]:
+    candidates = _get(payload, "memory", "memory_leak_candidates") or []
+    if candidates:
+        worst = max(candidates, key=lambda x: x.get("growth_pct", 0))
+        return [Issue(
+            code="P03", severity="high",
+            title=f"Memory leak detected in {worst.get('name', 'unknown')}",
+            description=(
+                f"{worst.get('name')} is using {worst.get('ram_mb_now')} MB of RAM, "
+                f"up {worst.get('growth_pct')}% since it started. "
+                "This process is hoarding memory without releasing it, slowing your entire system."
+            ),
+            fix_available=True,
+            fix_command="FIX_P03_RESTART",
+        )]
+    return []
+
+
+def detect_p04(payload: dict) -> list[Issue]:
+    items = _get(payload, "startup", "items") or []
+    ghosts = [i for i in items if i.get("category") == "ghost"]
+    if ghosts:
+        names = ", ".join(g.get("name", "?") for g in ghosts[:3])
+        return [Issue(
+            code="P04", severity="medium",
+            title=f"Ghost startup entries found ({len(ghosts)})",
+            description=(
+                f"Programs removed from your system are still listed as startup items: {names}. "
+                "These cause errors at boot and slow down startup. Safe to remove."
+            ),
+            fix_available=True,
+            fix_command="FIX_P04_GHOST",
+        )]
+    return []
+
+
+def detect_p05(payload: dict) -> list[Issue]:
+    partitions = _get(payload, "disk", "partitions") or []
+    for part in partitions:
+        usage = part.get("usage_pct", 0)
+        if usage > 90:
+            return [Issue(
+                code="P05", severity="high",
+                title=f"Disk almost full ({usage:.0f}%)",
+                description=(
+                    f"Your disk at {part.get('mountpoint')} is {usage:.0f}% full "
+                    f"({part.get('free_gb', 0):.1f} GB free). "
+                    "A full disk causes crashes, failed updates, and slowdowns. "
+                    "Delete large files or move them to external storage."
+                ),
+                fix_available=False,
+            )]
+    smart = _get(payload, "disk", "smart_data") or {}
+    if not smart.get("health_status", True):
+        return [Issue(
+            code="P05", severity="critical",
+            title="SSD health check failed",
+            description="Your SSD's SMART health check has failed. Replace the drive soon to avoid data loss.",
+            fix_available=False,
+        )]
+    return []
+
+
+def detect_p07(payload: dict) -> list[Issue]:
+    cloud = _get(payload, "network", "cloud_sync_processes") or []
+    if cloud:
+        names = ", ".join(p.get("name", "?") for p in cloud)
+        return [Issue(
+            code="P07", severity="medium",
+            title=f"Cloud sync consuming resources ({names})",
+            description=(
+                f"{names} is actively syncing files. This can consume significant CPU, "
+                "disk I/O, and bandwidth, slowing your system while it runs."
+            ),
+            fix_available=False,
+        )]
+    return []
+
+
+def detect_p08(payload: dict) -> list[Issue]:
+    top_cpu = _get(payload, "processes", "top_cpu") or []
+    wu_names = {"wuauserv", "tiworker", "tiworker.exe", "wuauclt"}
+    for proc in top_cpu:
+        if proc.get("name", "").lower() in wu_names and proc.get("cpu_pct", 0) > 20:
+            return [Issue(
+                code="P08", severity="medium",
+                title="Windows Update running in background",
+                description=(
+                    f"Windows Update ({proc['name']}) is using {proc['cpu_pct']:.0f}% CPU. "
+                    "This is normal but temporary. Your system will be faster once it completes."
+                ),
+                fix_available=False,
+            )]
+    return []
+
+
+def detect_p09(payload: dict) -> list[Issue]:
+    top_cpu = _get(payload, "processes", "top_cpu") or []
+    for proc in top_cpu:
+        if proc.get("name", "").lower() in KNOWN_AV and proc.get("cpu_pct", 0) > 30:
+            return [Issue(
+                code="P09", severity="low",
+                title="Antivirus scan running silently",
+                description=(
+                    f"{proc['name']} is using {proc['cpu_pct']:.0f}% CPU. "
+                    "Your antivirus is running a background scan. Performance will return to normal once complete."
+                ),
+                fix_available=False,
+            )]
+    return []
+
+
+def detect_p10(payload: dict) -> list[Issue]:
+    trim = _get(payload, "disk", "trim_enabled")
+    if trim is False:
+        return [Issue(
+            code="P10", severity="medium",
+            title="TRIM disabled on SSD",
+            description=(
+                "TRIM is disabled on your SSD. Without TRIM, your SSD cannot efficiently "
+                "manage deleted files, leading to gradual performance degradation over time."
+            ),
+            fix_available=True,
+            fix_command="FIX_P10_TRIM",
+        )]
+    return []
+
+
+_DETECTORS = [
+    detect_p01, detect_p02, detect_p03, detect_p04,
+    detect_p05, detect_p07, detect_p08, detect_p09, detect_p10,
+]
+
+
+def analyze(payload: dict) -> list[Issue]:
+    issues: list[Issue] = []
+    for detector in _DETECTORS:
+        try:
+            issues.extend(detector(payload))
+        except Exception:
+            pass
+    return issues

--- a/app/server/services/metrics_writer.py
+++ b/app/server/services/metrics_writer.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from typing import Any
+
+
+def extract(machine_uuid: str, payload: dict) -> dict[str, Any]:
+    cpu = payload.get("cpu", {})
+    mem = payload.get("memory", {})
+    disk = payload.get("disk", {})
+    net = payload.get("network", {})
+
+    partitions = disk.get("partitions") or []
+    disk_usage = partitions[0].get("usage_pct") if partitions else None
+
+    return {
+        "machine_id": machine_uuid,
+        "cpu_usage_pct": cpu.get("cpu_usage_pct"),
+        "cpu_temp_c": cpu.get("cpu_temp_c"),
+        "cpu_freq_mhz": cpu.get("cpu_freq_mhz"),
+        "cpu_freq_max_mhz": cpu.get("cpu_freq_max_mhz"),
+        "ram_usage_pct": mem.get("ram_usage_pct"),
+        "ram_available_gb": mem.get("ram_available_gb"),
+        "disk_read_mbps": disk.get("disk_read_mbps"),
+        "disk_write_mbps": disk.get("disk_write_mbps"),
+        "disk_usage_pct": disk_usage,
+        "net_upload_mbps": net.get("net_upload_mbps"),
+        "net_download_mbps": net.get("net_download_mbps"),
+    }

--- a/app/server/services/scorer.py
+++ b/app/server/services/scorer.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from models.schemas import Issue, ScoreResult
+
+_DEDUCTIONS: dict[str, dict[str, int]] = {
+    "P01": {"performance": 20},
+    "P02": {"storage": 25},
+    "P03": {"performance": 15},
+    "P04": {"stability": 5},
+    "P05": {"storage": 20},
+    "P06": {"stability": 10},
+    "P07": {"performance": 10},
+    "P08": {"performance": 5},
+    "P09": {"performance": 5, "security": 10},
+    "P10": {"storage": 10},
+}
+
+_WEIGHTS = {"performance": 0.40, "storage": 0.30, "security": 0.15, "stability": 0.15}
+
+
+def calculate(issues: list[Issue]) -> ScoreResult:
+    scores = {"performance": 100, "storage": 100, "security": 100, "stability": 100}
+
+    for issue in issues:
+        for dimension, deduction in _DEDUCTIONS.get(issue.code, {}).items():
+            scores[dimension] = max(0, scores[dimension] - deduction)
+
+    health = round(sum(scores[d] * w for d, w in _WEIGHTS.items()))
+
+    return ScoreResult(
+        health_score=max(0, min(100, health)),
+        score_performance=scores["performance"],
+        score_storage=scores["storage"],
+        score_security=scores["security"],
+        score_stability=scores["stability"],
+    )

--- a/app/server/tests/test_analyzer.py
+++ b/app/server/tests/test_analyzer.py
@@ -1,0 +1,171 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from services.analyzer import (
+    detect_p01, detect_p02, detect_p03, detect_p04,
+    detect_p05, detect_p07, detect_p08, detect_p09, detect_p10, analyze,
+)
+
+
+def _payload(**kwargs) -> dict:
+    base = {
+        "cpu": {}, "memory": {}, "disk": {}, "network": {},
+        "processes": {}, "startup": {},
+    }
+    for k, v in kwargs.items():
+        base[k] = v
+    return base
+
+
+class TestP01:
+    def test_detects_throttling_with_high_temp(self):
+        p = _payload(cpu={"throttling_detected": True, "cpu_temp_c": 91, "cpu_freq_mhz": 1000, "cpu_freq_max_mhz": 3000})
+        assert len(detect_p01(p)) == 1
+        assert detect_p01(p)[0].code == "P01"
+
+    def test_no_issue_without_throttling(self):
+        p = _payload(cpu={"throttling_detected": False, "cpu_temp_c": 60})
+        assert detect_p01(p) == []
+
+    def test_no_issue_throttling_but_low_temp(self):
+        p = _payload(cpu={"throttling_detected": True, "cpu_temp_c": 70})
+        assert detect_p01(p) == []
+
+
+class TestP02:
+    def test_detects_pending_sectors(self):
+        p = _payload(disk={"smart_data": {"pending_sectors": 3, "reallocated_sectors": 0}})
+        assert len(detect_p02(p)) == 1
+
+    def test_detects_reallocated_sectors(self):
+        p = _payload(disk={"smart_data": {"pending_sectors": 0, "reallocated_sectors": 10}})
+        assert len(detect_p02(p)) == 1
+
+    def test_no_issue_on_clean_disk(self):
+        p = _payload(disk={"smart_data": {"pending_sectors": 0, "reallocated_sectors": 0}})
+        assert detect_p02(p) == []
+
+    def test_no_crash_without_smart(self):
+        p = _payload(disk={})
+        assert detect_p02(p) == []
+
+
+class TestP03:
+    def test_detects_memory_leak(self):
+        p = _payload(memory={"memory_leak_candidates": [
+            {"name": "chrome", "ram_mb_now": 2000, "ram_mb_baseline": 100, "growth_pct": 1900}
+        ]})
+        issues = detect_p03(p)
+        assert len(issues) == 1
+        assert issues[0].code == "P03"
+        assert issues[0].fix_available is True
+
+    def test_no_issue_without_leaks(self):
+        p = _payload(memory={"memory_leak_candidates": []})
+        assert detect_p03(p) == []
+
+
+class TestP04:
+    def test_detects_ghost_startup(self):
+        p = _payload(startup={"items": [{"name": "OldApp", "path": "/missing/app", "category": "ghost"}]})
+        issues = detect_p04(p)
+        assert len(issues) == 1
+        assert issues[0].code == "P04"
+        assert issues[0].fix_available is True
+
+    def test_no_issue_without_ghosts(self):
+        p = _payload(startup={"items": [{"name": "Good", "path": "/usr/bin/good", "category": "useful"}]})
+        assert detect_p04(p) == []
+
+
+class TestP05:
+    def test_detects_full_disk(self):
+        p = _payload(disk={"partitions": [{"mountpoint": "/", "usage_pct": 95, "free_gb": 1.0}]})
+        issues = detect_p05(p)
+        assert len(issues) == 1
+        assert issues[0].code == "P05"
+
+    def test_no_issue_on_healthy_disk(self):
+        p = _payload(disk={"partitions": [{"mountpoint": "/", "usage_pct": 60, "free_gb": 100.0}]})
+        assert detect_p05(p) == []
+
+
+class TestP07:
+    def test_detects_cloud_sync(self):
+        p = _payload(network={"cloud_sync_processes": [{"name": "OneDrive", "read_mb": 500, "write_mb": 200}]})
+        issues = detect_p07(p)
+        assert len(issues) == 1
+        assert issues[0].code == "P07"
+
+    def test_no_issue_without_cloud_sync(self):
+        p = _payload(network={"cloud_sync_processes": []})
+        assert detect_p07(p) == []
+
+
+class TestP08:
+    def test_detects_windows_update(self):
+        p = _payload(processes={"top_cpu": [{"name": "TiWorker", "cpu_pct": 45}]})
+        issues = detect_p08(p)
+        assert len(issues) == 1
+        assert issues[0].code == "P08"
+
+    def test_no_issue_low_cpu(self):
+        p = _payload(processes={"top_cpu": [{"name": "TiWorker", "cpu_pct": 5}]})
+        assert detect_p08(p) == []
+
+
+class TestP09:
+    def test_detects_antivirus(self):
+        p = _payload(processes={"top_cpu": [{"name": "MsMpEng", "cpu_pct": 40}]})
+        issues = detect_p09(p)
+        assert len(issues) == 1
+        assert issues[0].code == "P09"
+
+    def test_no_issue_low_av_cpu(self):
+        p = _payload(processes={"top_cpu": [{"name": "MsMpEng", "cpu_pct": 5}]})
+        assert detect_p09(p) == []
+
+
+class TestP10:
+    def test_detects_trim_disabled(self):
+        p = _payload(disk={"trim_enabled": False})
+        issues = detect_p10(p)
+        assert len(issues) == 1
+        assert issues[0].code == "P10"
+        assert issues[0].fix_available is True
+
+    def test_no_issue_trim_enabled(self):
+        p = _payload(disk={"trim_enabled": True})
+        assert detect_p10(p) == []
+
+    def test_no_issue_trim_unknown(self):
+        p = _payload(disk={"trim_enabled": None})
+        assert detect_p10(p) == []
+
+
+class TestAnalyzePipeline:
+    def test_returns_multiple_issues(self):
+        p = _payload(
+            cpu={"throttling_detected": True, "cpu_temp_c": 95},
+            disk={"smart_data": {"pending_sectors": 5, "reallocated_sectors": 0},
+                  "trim_enabled": False, "partitions": []},
+            startup={"items": [{"name": "Ghost", "category": "ghost"}]},
+        )
+        issues = analyze(p)
+        codes = {i.code for i in issues}
+        assert "P02" in codes
+        assert "P04" in codes
+        assert "P10" in codes
+
+    def test_clean_system_returns_no_issues(self):
+        p = _payload(
+            cpu={"throttling_detected": False, "cpu_temp_c": 45},
+            disk={"smart_data": {"pending_sectors": 0, "reallocated_sectors": 0},
+                  "trim_enabled": True, "partitions": [{"usage_pct": 50, "free_gb": 200}]},
+            memory={"memory_leak_candidates": []},
+            network={"cloud_sync_processes": []},
+            startup={"items": []},
+            processes={"top_cpu": []},
+        )
+        assert analyze(p) == []

--- a/app/server/tests/test_scorer.py
+++ b/app/server/tests/test_scorer.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from models.schemas import Issue
+from services.scorer import calculate
+
+
+def _issue(code: str) -> Issue:
+    return Issue(code=code, severity="high", title=code, description="")
+
+
+class TestScorer:
+    def test_clean_system_scores_100(self):
+        result = calculate([])
+        assert result.health_score == 100
+        assert result.score_performance == 100
+        assert result.score_storage == 100
+
+    def test_p01_deducts_performance(self):
+        result = calculate([_issue("P01")])
+        assert result.score_performance == 80
+        assert result.score_storage == 100
+
+    def test_p02_deducts_storage(self):
+        result = calculate([_issue("P02")])
+        assert result.score_storage == 75
+        assert result.score_performance == 100
+
+    def test_multiple_issues_stack(self):
+        result = calculate([_issue("P01"), _issue("P03"), _issue("P02")])
+        assert result.score_performance == 65  # 100 - 20 - 15
+        assert result.score_storage == 75      # 100 - 25
+
+    def test_scores_clamped_at_zero(self):
+        issues = [_issue("P01"), _issue("P03"), _issue("P07"), _issue("P08"), _issue("P09")]
+        result = calculate(issues)
+        assert result.score_performance >= 0
+
+    def test_health_score_weighted_average(self):
+        result = calculate([_issue("P01")])
+        # performance=80, storage=100, security=100, stability=100
+        expected = round(80 * 0.40 + 100 * 0.30 + 100 * 0.15 + 100 * 0.15)
+        assert result.health_score == expected
+
+    def test_health_score_clamped_to_100(self):
+        result = calculate([])
+        assert result.health_score <= 100
+
+    def test_p09_deducts_both_performance_and_security(self):
+        result = calculate([_issue("P09")])
+        assert result.score_performance == 95
+        assert result.score_security == 90

--- a/app/server/uv.lock
+++ b/app/server/uv.lock
@@ -453,6 +453,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -733,6 +742,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1086,6 +1104,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1209,6 +1256,13 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.97.0" },
@@ -1219,6 +1273,13 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "supabase", specifier = ">=2.29.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.46.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `services/analyzer.py`: 9 independent detectors (P01–P10) — each returns plain-language `Issue` with severity
- `services/scorer.py`: weighted Health Score calculator (Performance 40%, Storage 30%, Security 15%, Stability 15%)
- `services/metrics_writer.py`: flat metric extraction from collector payload  
- `routers/machines.py`: `POST /api/v1/machines/register` with upsert + last_seen update
- `routers/scans.py`: `POST /api/v1/machines/{id}/scan` full pipeline (analyze → score → persist) + `GET` latest scan

## Test plan
- [x] `uv run pytest` → 32/32 passed (24 analyzer + 8 scorer)
- [ ] `POST /api/v1/machines/register` → returns machine UUID
- [ ] `POST /api/v1/machines/{id}/scan` → detects issues + returns health_score

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)