### PR TITLE
feat: Claude AI explainer + fix system (issues #5 + #6)

### DIFF
--- a/app/agent/fixers/disk_fixer.py
+++ b/app/agent/fixers/disk_fixer.py
@@ -1,2 +1,74 @@
+import os
+import platform
+import subprocess
+import time
+from pathlib import Path
+
+MAX_TEMP_AGE_DAYS = 7
+
+
+def enable_trim() -> tuple[bool, str]:
+    sys = platform.system()
+    try:
+        if sys == "Windows":
+            r = subprocess.run(
+                ["fsutil", "behavior", "set", "DisableDeleteNotify", "0"],
+                capture_output=True, text=True, timeout=10
+            )
+            if r.returncode == 0:
+                return True, "TRIM enabled via fsutil"
+            return False, f"fsutil failed: {r.stderr}"
+
+        elif sys == "Darwin":
+            return False, "TRIM on macOS is managed by the OS. Enable from System Settings > General > Storage."
+
+        else:  # Linux
+            r = subprocess.run(
+                ["systemctl", "enable", "--now", "fstrim.timer"],
+                capture_output=True, text=True, timeout=10
+            )
+            if r.returncode == 0:
+                return True, "TRIM timer enabled via systemctl"
+            return False, f"systemctl failed: {r.stderr}"
+
+    except Exception as e:
+        return False, f"Error enabling TRIM: {e}"
+
+
+def clear_temp_files() -> tuple[bool, str]:
+    sys = platform.system()
+    deleted = 0
+    errors = 0
+    cutoff = time.time() - MAX_TEMP_AGE_DAYS * 86400
+
+    if sys == "Windows":
+        dirs = [
+            Path(os.path.expandvars("%TEMP%")),
+            Path(os.path.expandvars("%TMP%")),
+        ]
+    elif sys == "Darwin":
+        dirs = [Path.home() / "Library/Caches"]
+    else:
+        dirs = [Path("/tmp")]
+
+    for temp_dir in dirs:
+        if not temp_dir.exists():
+            continue
+        for f in temp_dir.rglob("*"):
+            try:
+                if f.is_file() and f.stat().st_mtime < cutoff:
+                    f.unlink()
+                    deleted += 1
+            except Exception:
+                errors += 1
+
+    return True, f"Cleared {deleted} temp files ({errors} skipped)"
+
+
 def fix(params: dict) -> tuple[bool, str]:
-    return False, "Not implemented"
+    action = params.get("action", "")
+    if action == "trim":
+        return enable_trim()
+    if action == "clear_temp":
+        return clear_temp_files()
+    return False, f"Unknown disk fix action: {action}"

--- a/app/agent/fixers/process_fixer.py
+++ b/app/agent/fixers/process_fixer.py
@@ -1,0 +1,46 @@
+import psutil
+
+PROTECTED_PIDS = frozenset(range(100))
+PROTECTED_NAMES = frozenset({
+    "launchd", "systemd", "kernel", "kernel_task", "winlogon",
+    "csrss", "lsass", "services", "smss", "wininit", "svchost",
+    "init", "kthreadd",
+})
+
+
+def kill_process(pid: int, name: str) -> tuple[bool, str]:
+    if pid in PROTECTED_PIDS:
+        return False, f"Cannot kill protected PID {pid}"
+
+    if name.lower() in PROTECTED_NAMES:
+        return False, f"Cannot kill protected process: {name}"
+
+    try:
+        proc = psutil.Process(pid)
+        actual_name = proc.name()
+
+        if actual_name.lower() != name.lower():
+            return False, f"Process name mismatch: expected {name}, found {actual_name}"
+
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except psutil.TimeoutExpired:
+            proc.kill()
+
+        return True, f"Terminated process {name} (PID {pid})"
+
+    except psutil.NoSuchProcess:
+        return False, f"Process {name} (PID {pid}) no longer exists"
+    except psutil.AccessDenied:
+        return False, f"Access denied when terminating {name} (PID {pid})"
+    except Exception as e:
+        return False, f"Error killing process: {e}"
+
+
+def fix(params: dict) -> tuple[bool, str]:
+    pid = params.get("pid")
+    name = params.get("name", "")
+    if pid is None or not name:
+        return False, "pid and name are required"
+    return kill_process(int(pid), name)

--- a/app/agent/fixers/startup_fixer.py
+++ b/app/agent/fixers/startup_fixer.py
@@ -1,2 +1,74 @@
+import platform
+import subprocess
+from pathlib import Path
+
+
+def _safe_name(name: str) -> str:
+    return name.replace("..", "").replace("/", "").replace("\\", "").strip()
+
+
+def disable_startup_item(name: str, source: str) -> tuple[bool, str]:
+    name = _safe_name(name)
+    sys = platform.system()
+
+    try:
+        if sys == "Darwin":
+            dirs = [
+                Path.home() / "Library/LaunchAgents",
+                Path("/Library/LaunchAgents"),
+                Path("/Library/LaunchDaemons"),
+            ]
+            for d in dirs:
+                plist = d / f"{name}.plist"
+                if plist.exists():
+                    r = subprocess.run(
+                        ["launchctl", "unload", str(plist)],
+                        capture_output=True, text=True, timeout=10
+                    )
+                    if r.returncode == 0:
+                        return True, f"Disabled {name} via launchctl"
+                    return False, f"launchctl unload failed: {r.stderr}"
+            return False, f"Plist not found for {name}"
+
+        elif sys == "Windows":
+            import winreg  # type: ignore
+            for hive, subkey in [
+                (winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Run"),
+                (winreg.HKEY_LOCAL_MACHINE, r"Software\Microsoft\Windows\CurrentVersion\Run"),
+            ]:
+                try:
+                    key = winreg.OpenKey(hive, subkey, 0, winreg.KEY_SET_VALUE | winreg.KEY_READ)
+                    winreg.DeleteValue(key, name)
+                    return True, f"Removed {name} from registry Run key"
+                except FileNotFoundError:
+                    continue
+                except Exception as e:
+                    return False, f"Registry error: {e}"
+            return False, f"Registry key {name} not found"
+
+        else:  # Linux
+            autostart = Path.home() / ".config/autostart" / f"{name}.desktop"
+            if autostart.exists():
+                content = autostart.read_text(errors="ignore")
+                if "Hidden=true" not in content:
+                    autostart.write_text(content + "\nHidden=true")
+                return True, f"Disabled {name} in autostart"
+            return False, f"Desktop file not found: {autostart}"
+
+    except Exception as e:
+        return False, f"Error disabling startup item: {e}"
+
+
+def remove_ghost_entry(name: str, source: str) -> tuple[bool, str]:
+    return disable_startup_item(name, source)
+
+
 def fix(params: dict) -> tuple[bool, str]:
-    return False, "Not implemented"
+    name = params.get("name", "")
+    source = params.get("source", "")
+    action = params.get("action", "disable")
+    if not name:
+        return False, "No startup item name provided"
+    if action == "remove":
+        return remove_ghost_entry(name, source)
+    return disable_startup_item(name, source)

--- a/app/agent/main.py
+++ b/app/agent/main.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 
 from client import AgentClient
 from collectors import cpu, memory, disk, network, processes, startup
+from fixers import startup_fixer, disk_fixer, process_fixer
 
 load_dotenv()
 
@@ -53,6 +54,24 @@ def machine_info(machine_id: str) -> dict:
     }
 
 
+def _execute_fix(cmd: dict) -> tuple[bool, str]:
+    fix_code = cmd.get("fix_code", "")
+    params = cmd.get("params", {})
+
+    if fix_code in ("FIX_P04_GHOST", "FIX_STARTUP_TOGGLE"):
+        return startup_fixer.fix(params)
+    if fix_code == "FIX_P10_TRIM":
+        return disk_fixer.fix({"action": "trim"})
+    if fix_code == "FIX_CLR_TEMP":
+        return disk_fixer.fix({"action": "clear_temp"})
+    if fix_code == "FIX_P03_RESTART":
+        return process_fixer.fix(params)
+    if fix_code == "FIX_P01_INFO":
+        return True, "Thermal throttling info: clean vents and check thermal paste. No automated fix available."
+
+    return False, f"Unknown fix code: {fix_code}"
+
+
 def run(debug: bool = False) -> None:
     machine_id = load_or_create_machine_id()
     client = AgentClient(machine_id)
@@ -93,7 +112,11 @@ def run(debug: bool = False) -> None:
                 cmds = client.get_pending_commands()
                 for cmd in cmds:
                     if debug:
-                        print(f"[agent] fix command: {cmd}")
+                        print(f"[agent] executing fix: {cmd.get('fix_code')}")
+                    success, output = _execute_fix(cmd)
+                    client.report_fix_result(cmd["id"], success, output)
+                    if debug:
+                        print(f"[agent] fix result: success={success} output={output}")
             except Exception as e:
                 if debug:
                     print(f"[agent] fix poll error: {e}")

--- a/app/server/db/migrations/002_pending_commands.sql
+++ b/app/server/db/migrations/002_pending_commands.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS pending_commands (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  machine_id   UUID REFERENCES machines(id) ON DELETE CASCADE,
+  fix_code     TEXT NOT NULL,
+  params       JSONB DEFAULT '{}',
+  status       TEXT DEFAULT 'queued' CHECK (status IN ('queued','running','success','failed')),
+  created_at   TIMESTAMPTZ DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  output       TEXT,
+  success      BOOLEAN
+);

--- a/app/server/main.py
+++ b/app/server/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import health, machines, scans
+from routers import health, machines, scans, ai, dashboard, fixes
 
 app = FastAPI(title="SysDoc API", version="0.1.0")
 
@@ -15,3 +15,6 @@ app.add_middleware(
 app.include_router(health.router)
 app.include_router(machines.router)
 app.include_router(scans.router)
+app.include_router(ai.router)
+app.include_router(dashboard.router)
+app.include_router(fixes.router)

--- a/app/server/routers/ai.py
+++ b/app/server/routers/ai.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+from datetime import datetime
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from db.supabase import get_client
+from services.ai_explainer import generate_explanation
+
+router = APIRouter(prefix="/api/v1")
+
+
+class ExplainBody(BaseModel):
+    machine_id: str
+
+
+@router.post("/ai/explain")
+async def explain(body: ExplainBody):
+    db = get_client()
+
+    machine = db.table("machines").select("*").eq("machine_id", body.machine_id).execute()
+    if not machine.data:
+        raise HTTPException(status_code=404, detail="Machine not found")
+
+    machine_row = machine.data[0]
+    machine_uuid = machine_row["id"]
+
+    scan = (
+        db.table("scans")
+        .select("*")
+        .eq("machine_id", machine_uuid)
+        .order("scanned_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    if not scan.data:
+        raise HTTPException(status_code=404, detail="No scans found for machine")
+
+    scan_row = scan.data[0]
+
+    if (scan_row.get("health_score") or 100) >= 70:
+        return {"explanation": None, "cached": False, "generated_at": None, "skipped": "health_score >= 70"}
+
+    issues = (
+        db.table("issues")
+        .select("*")
+        .eq("scan_id", scan_row["id"])
+        .is_("resolved_at", None)
+        .execute()
+    )
+
+    explanation, cached = await generate_explanation(machine_row, scan_row, issues.data or [])
+
+    return {
+        "explanation": explanation,
+        "cached": cached,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+    }

--- a/app/server/routers/dashboard.py
+++ b/app/server/routers/dashboard.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+from fastapi import APIRouter, HTTPException
+from db.supabase import get_client
+
+router = APIRouter(prefix="/api/v1")
+
+
+@router.get("/machines/{machine_id}/dashboard")
+async def get_dashboard(machine_id: str):
+    db = get_client()
+
+    machine = db.table("machines").select("*").eq("machine_id", machine_id).execute()
+    if not machine.data:
+        raise HTTPException(status_code=404, detail="Machine not found")
+
+    machine_row = machine.data[0]
+    machine_uuid = machine_row["id"]
+
+    scan = (
+        db.table("scans")
+        .select("*")
+        .eq("machine_id", machine_uuid)
+        .order("scanned_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+
+    scan_row = scan.data[0] if scan.data else None
+    issues = []
+    ai_explanation = None
+
+    if scan_row:
+        issues_result = (
+            db.table("issues")
+            .select("*")
+            .eq("scan_id", scan_row["id"])
+            .is_("resolved_at", None)
+            .execute()
+        )
+        issues = issues_result.data or []
+        ai_explanation = (scan_row.get("raw_data") or {}).get("ai_explanation")
+
+    return {
+        "machine": machine_row,
+        "scan": {**scan_row, "issues": issues, "ai_explanation": ai_explanation} if scan_row else None,
+    }
+
+
+@router.get("/machines/{machine_id}/metrics")
+async def get_metrics(machine_id: str, hours: int = 1):
+    db = get_client()
+
+    machine = db.table("machines").select("id").eq("machine_id", machine_id).execute()
+    if not machine.data:
+        raise HTTPException(status_code=404, detail="Machine not found")
+
+    machine_uuid = machine.data[0]["id"]
+
+    metrics = (
+        db.table("metrics")
+        .select("*")
+        .eq("machine_id", machine_uuid)
+        .order("recorded_at", desc=True)
+        .limit(hours * 12)
+        .execute()
+    )
+
+    return list(reversed(metrics.data or []))
+
+
+@router.get("/machines/{machine_id}/issues")
+async def get_machine_issues(machine_id: str):
+    db = get_client()
+
+    machine = db.table("machines").select("id").eq("machine_id", machine_id).execute()
+    if not machine.data:
+        raise HTTPException(status_code=404, detail="Machine not found")
+
+    machine_uuid = machine.data[0]["id"]
+
+    issues = (
+        db.table("issues")
+        .select("*")
+        .eq("machine_id", machine_uuid)
+        .is_("resolved_at", None)
+        .order("created_at", desc=True)
+        .execute()
+    )
+
+    return issues.data or []

--- a/app/server/routers/fixes.py
+++ b/app/server/routers/fixes.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+from datetime import datetime
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from db.supabase import get_client
+
+router = APIRouter(prefix="/api/v1")
+
+ALLOWED_FIX_CODES = frozenset({"FIX_P04_GHOST", "FIX_P10_TRIM", "FIX_CLR_TEMP", "FIX_P01_INFO", "FIX_P03_RESTART", "FIX_STARTUP_TOGGLE"})
+
+
+class FixBody(BaseModel):
+    issue_id: str
+    fix_code: str
+
+
+class FixResultBody(BaseModel):
+    success: bool
+    output: str
+
+
+def _resolve_machine_uuid(db, machine_id: str) -> str:
+    result = db.table("machines").select("id").eq("machine_id", machine_id).execute()
+    if not result.data:
+        raise HTTPException(status_code=404, detail="Machine not found")
+    return result.data[0]["id"]
+
+
+@router.post("/machines/{machine_id}/fix")
+async def queue_fix(machine_id: str, body: FixBody):
+    if body.fix_code not in ALLOWED_FIX_CODES:
+        raise HTTPException(status_code=400, detail=f"Unknown fix code: {body.fix_code}")
+
+    db = get_client()
+    machine_uuid = _resolve_machine_uuid(db, machine_id)
+
+    cmd = db.table("pending_commands").insert({
+        "machine_id": machine_uuid,
+        "fix_code": body.fix_code,
+        "params": {"issue_id": body.issue_id},
+        "status": "queued",
+    }).execute()
+
+    if not cmd.data:
+        raise HTTPException(status_code=500, detail="Failed to queue fix")
+
+    db.table("fix_history").insert({
+        "machine_id": machine_uuid,
+        "issue_id": body.issue_id,
+        "fix_code": body.fix_code,
+    }).execute()
+
+    return {"fix_id": cmd.data[0]["id"], "status": "queued"}
+
+
+@router.get("/machines/{machine_id}/pending_commands")
+async def get_pending_commands(machine_id: str):
+    db = get_client()
+    machine_uuid = _resolve_machine_uuid(db, machine_id)
+
+    cmds = (
+        db.table("pending_commands")
+        .select("*")
+        .eq("machine_id", machine_uuid)
+        .eq("status", "queued")
+        .order("created_at")
+        .execute()
+    )
+
+    return {"commands": cmds.data or []}
+
+
+@router.post("/machines/{machine_id}/fix/{fix_id}/result")
+async def report_fix_result(machine_id: str, fix_id: str, body: FixResultBody):
+    db = get_client()
+    machine_uuid = _resolve_machine_uuid(db, machine_id)
+
+    db.table("pending_commands").update({
+        "status": "success" if body.success else "failed",
+        "output": body.output,
+        "success": body.success,
+        "completed_at": datetime.utcnow().isoformat(),
+    }).eq("id", fix_id).eq("machine_id", machine_uuid).execute()
+
+    db.table("fix_history").update({
+        "success": body.success,
+        "output": body.output,
+    }).eq("machine_id", machine_uuid).execute()
+
+    return {"ok": True}
+
+
+@router.get("/machines/{machine_id}/fix/{fix_id}")
+async def get_fix_status(machine_id: str, fix_id: str):
+    db = get_client()
+    machine_uuid = _resolve_machine_uuid(db, machine_id)
+
+    cmd = (
+        db.table("pending_commands")
+        .select("id, status, output, success, created_at, completed_at, fix_code")
+        .eq("id", fix_id)
+        .eq("machine_id", machine_uuid)
+        .execute()
+    )
+
+    if not cmd.data:
+        raise HTTPException(status_code=404, detail="Fix command not found")
+
+    return cmd.data[0]

--- a/app/server/routers/scans.py
+++ b/app/server/routers/scans.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import os
 from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -6,6 +7,7 @@ from db.supabase import get_client
 from services.analyzer import analyze
 from services.scorer import calculate
 from services.metrics_writer import extract
+from services.ai_explainer import generate_explanation
 
 router = APIRouter(prefix="/api/v1")
 
@@ -39,6 +41,28 @@ async def ingest_scan(machine_id: str, body: ScanBody):
 
     issues = analyze(payload)
     score_result = calculate(issues)
+
+    machine_row = db.table("machines").select("*").eq("id", machine_uuid).execute().data[0]
+
+    ai_explanation: str | None = None
+    if score_result.health_score < 70 and os.getenv("ANTHROPIC_API_KEY"):
+        scan_stub = {
+            "health_score": score_result.health_score,
+            "score_performance": score_result.score_performance,
+            "score_storage": score_result.score_storage,
+            "score_security": score_result.score_security,
+            "score_stability": score_result.score_stability,
+        }
+        issue_dicts = [
+            {"issue_code": i.code, "severity": i.severity, "title": i.title, "description": i.description}
+            for i in issues
+        ]
+        try:
+            ai_explanation, _ = await generate_explanation(machine_row, scan_stub, issue_dicts)
+        except Exception:
+            pass
+
+    payload["ai_explanation"] = ai_explanation
 
     scan = (
         db.table("scans")

--- a/app/server/services/ai_explainer.py
+++ b/app/server/services/ai_explainer.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+import os
+from datetime import date
+from anthropic import AsyncAnthropic
+
+_client: AsyncAnthropic | None = None
+_cache: dict[str, tuple[str, str]] = {}  # key → (explanation, date_str)
+
+SYSTEM_PROMPT = """You are SysDoc, an AI system diagnostics expert. You analyze computer performance data and explain problems in plain language that non-technical users can understand.
+Rules:
+- Write in 2-4 short paragraphs maximum
+- Start with the most impactful problem
+- Use analogies when helpful (e.g. "like a car engine overheating")
+- End with one clear recommended action
+- Never use technical jargon without explaining it
+- Speak directly to the user ("your computer", "you should")
+- Language: match the OS locale (es for Spanish systems, en for English)"""
+
+
+def _get_client() -> AsyncAnthropic:
+    global _client
+    if _client is None:
+        _client = AsyncAnthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+    return _client
+
+
+def _cache_key(machine_id: str) -> str:
+    return f"{machine_id}:{date.today().isoformat()}"
+
+
+def _build_prompt(machine: dict, scan: dict, issues: list[dict]) -> str:
+    issue_lines = "\n".join(
+        f"- [{i.get('severity', '?')}] {i.get('issue_code', '?')}: {i.get('title', '')} — {i.get('description', '')[:120]}"
+        for i in issues[:5]
+    )
+    return (
+        f"Machine: {machine.get('hostname', 'unknown')} running {machine.get('os_name', 'unknown')} "
+        f"on {machine.get('cpu_model', 'unknown')}\n"
+        f"Health Score: {scan.get('health_score', 0)}/100 "
+        f"(Performance: {scan.get('score_performance', 0)}, Storage: {scan.get('score_storage', 0)}, "
+        f"Security: {scan.get('score_security', 0)}, Stability: {scan.get('score_stability', 0)})\n\n"
+        f"Active issues detected:\n{issue_lines or '(none)'}\n\n"
+        "Explain in plain language why this computer is slow and what the user should do."
+    )
+
+
+async def generate_explanation(
+    machine: dict,
+    scan: dict,
+    issues: list[dict],
+) -> tuple[str, bool]:
+    machine_id = machine.get("machine_id") or machine.get("id", "unknown")
+    key = _cache_key(machine_id)
+
+    if key in _cache:
+        explanation, _ = _cache[key]
+        return explanation, True
+
+    client = _get_client()
+    user_prompt = _build_prompt(machine, scan, issues)
+
+    response = await client.messages.create(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=300,
+        temperature=0.3,
+        system=[
+            {
+                "type": "text",
+                "text": SYSTEM_PROMPT,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        messages=[{"role": "user", "content": user_prompt}],
+    )
+
+    explanation = response.content[0].text  # type: ignore
+    _cache[key] = (explanation, date.today().isoformat())
+    return explanation, False

--- a/app/server/tests/test_ai_explainer.py
+++ b/app/server/tests/test_ai_explainer.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch, MagicMock
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pytest
+from services import ai_explainer
+
+
+@pytest.mark.asyncio
+async def test_generates_explanation():
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Your CPU is overheating. Clean the vents.")]
+
+    mock_client = AsyncMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+    ai_explainer._cache.clear()
+    ai_explainer._client = mock_client
+
+    machine = {"machine_id": "test-123", "hostname": "MyPC", "os_name": "macOS", "cpu_model": "M2"}
+    scan = {"health_score": 55, "score_performance": 65, "score_storage": 80, "score_security": 90, "score_stability": 85}
+    issues = [{"issue_code": "P01", "severity": "high", "title": "Thermal throttling", "description": "CPU too hot"}]
+
+    explanation, cached = await ai_explainer.generate_explanation(machine, scan, issues)
+
+    assert "CPU" in explanation
+    assert cached is False
+    mock_client.messages.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_returns_cached_on_second_call():
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Cached explanation")]
+
+    mock_client = AsyncMock()
+    mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+    ai_explainer._cache.clear()
+    ai_explainer._client = mock_client
+
+    machine = {"machine_id": "cache-test", "hostname": "PC", "os_name": "Linux", "cpu_model": "i7"}
+    scan = {"health_score": 45, "score_performance": 50, "score_storage": 60, "score_security": 70, "score_stability": 80}
+    issues = []
+
+    _, cached1 = await ai_explainer.generate_explanation(machine, scan, issues)
+    _, cached2 = await ai_explainer.generate_explanation(machine, scan, issues)
+
+    assert cached1 is False
+    assert cached2 is True
+    assert mock_client.messages.create.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_prompt_includes_machine_info():
+    machine = {"machine_id": "m1", "hostname": "WorkPC", "os_name": "Windows", "cpu_model": "Ryzen 9"}
+    scan = {"health_score": 40, "score_performance": 30, "score_storage": 70, "score_security": 80, "score_stability": 75}
+    issues = [{"issue_code": "P03", "severity": "high", "title": "Memory leak", "description": "Process using too much RAM"}]
+
+    prompt = ai_explainer._build_prompt(machine, scan, issues)
+
+    assert "WorkPC" in prompt
+    assert "Windows" in prompt
+    assert "Ryzen 9" in prompt
+    assert "P03" in prompt
+    assert "Memory leak" in prompt


### PR DESCRIPTION
## Summary

### Issue #5 — Claude AI Root Cause Explainer
- `services/ai_explainer.py`: Haiku model with system prompt caching (`cache_control: ephemeral`), 24h in-memory cache keyed by machine_id+date
- `routers/ai.py`: `POST /api/v1/ai/explain` — returns explanation + cached flag
- `routers/dashboard.py`: new endpoints `/dashboard`, `/metrics`, `/issues` 
- Scan pipeline auto-generates explanation when `health_score < 70` (stored in `raw_data.ai_explanation`)

### Issue #6 — Fix System
- `db/migrations/002_pending_commands.sql`: pending_commands table
- `routers/fixes.py`: 4 endpoints with allowlisted fix codes only (no injection possible)
- `fixers/startup_fixer.py`: cross-platform disable (macOS launchctl, Windows registry, Linux autostart)
- `fixers/disk_fixer.py`: TRIM enable + temp file cleanup
- `fixers/process_fixer.py`: safe termination with protected PID/name allowlist
- Agent main loop polls + executes queued fixes

## Test plan
- [x] `uv run pytest` → 35/35 passing
- [ ] `POST /api/v1/ai/explain` with real `ANTHROPIC_API_KEY` returns human-readable explanation
- [ ] Fix button on ghost startup item queues command → agent executes → reports success

Closes #5
Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)